### PR TITLE
Switch to non-blocking thread for handling search task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ Plugins/*/Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+Source/BlueprintSearchVSExtension/obj/*
+Source/BlueprintSearchVSExtension/bin/*

--- a/Source/BlueprintSearchVSExtension/BlueprintSearchVS.csproj
+++ b/Source/BlueprintSearchVSExtension/BlueprintSearchVS.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Source\Commands\CommandHelpers\DeserializeHelper.cs" />
     <Compile Include="Config\Properties\AssemblyInfo.cs" />
     <Compile Include="Source\BlueprintSearchVSPackage.cs" />
+    <Compile Include="Source\UI\ToolWindows\BlueprintSearchWindow\BlueprintSearchVSWindowVM.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/Source/BlueprintSearchVSExtension/Source/Commands/BlueprintSearchVSWindowCommand.cs
+++ b/Source/BlueprintSearchVSExtension/Source/Commands/BlueprintSearchVSWindowCommand.cs
@@ -66,6 +66,9 @@ namespace BlueprintSearch
 			}
 		}
 
+		// the window pane created when the command was executed
+		private BlueprintSearchVSWindow window = null;
+
 		/// <summary>
 		/// Initializes the singleton instance of the command.
 		/// </summary>
@@ -92,7 +95,8 @@ namespace BlueprintSearch
 			// Get the instance number 0 of this tool window. This window is single instance so this instance
 			// is actually the only one.
 			// The last flag is set to true so that if the tool window does not exists it will be created.
-			ToolWindowPane window = this.package.FindToolWindow(typeof(BlueprintSearchVSWindow), 0, true);
+
+			window = (BlueprintSearchVSWindow)this.package.FindToolWindow(typeof(BlueprintSearchVSWindow), 0, true);
 			if ((null == window) || (null == window.Frame))
 			{
 				throw new NotSupportedException("Cannot create tool window");
@@ -100,6 +104,11 @@ namespace BlueprintSearch
 
 			IVsWindowFrame windowFrame = (IVsWindowFrame)window.Frame;
 			Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
+		}
+
+		public void Shutdown()
+		{
+			window?.Shutdown();
 		}
 	}
 }

--- a/Source/BlueprintSearchVSExtension/Source/Commands/CommandHandlers/ExecuteSearchHandler.cs
+++ b/Source/BlueprintSearchVSExtension/Source/Commands/CommandHandlers/ExecuteSearchHandler.cs
@@ -19,7 +19,7 @@ namespace BlueprintSearch.Commands.CommandHandlers
 
 		private const string CommandLineArguments = "-NoShaderCompile -SILENT -run=FiB";
 
-		public async Task MakeSearchAsync(string InSearchValue, CancellationToken cancellationToken)
+		public async Task MakeSearchAsync(string InSearchValue, CancellationToken CancellationToken)
 		{
 			Results.Clear();
 
@@ -41,13 +41,13 @@ namespace BlueprintSearch.Commands.CommandHandlers
 				Proc.StartInfo.UseShellExecute = true;
 				Proc.Start();
 
-				while (!Proc.HasExited && !cancellationToken.IsCancellationRequested)
+				while (!Proc.HasExited && !CancellationToken.IsCancellationRequested)
 				{
 					// need to check back periodically to see if the task is finished/cancelled without doing a busy wait.
 					await Task.Delay(20);
 				}
 
-				if (cancellationToken.IsCancellationRequested)
+				if (CancellationToken.IsCancellationRequested)
 				{
 					Proc.Kill();
 					Results = new List<BlueprintJsonObject>() { new BlueprintJsonObject("Search cancelled") };

--- a/Source/BlueprintSearchVSExtension/Source/Commands/CommandHandlers/ExecuteSearchHandler.cs
+++ b/Source/BlueprintSearchVSExtension/Source/Commands/CommandHandlers/ExecuteSearchHandler.cs
@@ -6,24 +6,32 @@ using BlueprintSearch.Commands.CommandHelpers;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
-using System.Windows;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BlueprintSearch.Commands.CommandHandlers
 {
 	public class ExecuteSearchHandler
 	{
+		public List<BlueprintJsonObject> Results = new List<BlueprintJsonObject>();
+
+		public List<string> ErrorMessages = new List<string>();
+
 		private const string CommandLineArguments = "-NoShaderCompile -SILENT -run=FiB";
 
-		public List<BlueprintJsonObject> MakeSearch(string InSearchValue)
+		public async Task MakeSearchAsync(string InSearchValue, CancellationToken cancellationToken)
 		{
-			List<BlueprintJsonObject> SearchResults = new List<BlueprintJsonObject>() { new BlueprintJsonObject(string.Empty) };
-			bool PathsFound = true;
-			if (PathFinderHelper.UEEditorFilePath.Length == 0 || PathFinderHelper.UProjectFilePath.Length == 0 || PathFinderHelper.WorkingDirectoryPath.Length == 0)
-			{
-				PathsFound = PathFinderHelper.FindPaths();
-			}
+			Results.Clear();
 
-			if (PathsFound)
+			if (string.IsNullOrEmpty(InSearchValue))
+			{
+				ErrorMessages.Add("BlueprintSearchVS has not been given a valid search term to search for.");
+			}
+			else if (string.IsNullOrEmpty(PathFinderHelper.UProjectFilePath))
+			{
+				ErrorMessages.Add("BlueprintSearchVS has not found a valid .uproject file from the loaded list of projects, please ensure you're in the correct solution and it has been built successfully.");
+			}
+			else
 			{
 				string Arguments = PathFinderHelper.UProjectFilePath + " " + CommandLineArguments + " " + PathFinderHelper.AddQuotes(InSearchValue);
 				System.Diagnostics.Process Proc = new System.Diagnostics.Process();
@@ -32,27 +40,38 @@ namespace BlueprintSearch.Commands.CommandHandlers
 				Proc.StartInfo.Arguments = Arguments;
 				Proc.StartInfo.UseShellExecute = true;
 				Proc.Start();
-				Proc.WaitForExit();
+
+				while (!Proc.HasExited && !cancellationToken.IsCancellationRequested)
+				{
+					// need to check back periodically to see if the task is finished/cancelled without doing a busy wait.
+					await Task.Delay(20);
+				}
+
+				if (cancellationToken.IsCancellationRequested)
+				{
+					Proc.Kill();
+					Results = new List<BlueprintJsonObject>() { new BlueprintJsonObject("Search cancelled") };
+					return;
+				}
+
 				string SearchResultsPath = Path.Combine(PathFinderHelper.UEEditorFilePath, "SearchResults.json");
 				if (File.Exists(SearchResultsPath))
 				{
 					using (StreamReader Reader = new StreamReader(SearchResultsPath))
 					{
-						SearchResults = JsonConvert.DeserializeObject<List<BlueprintJsonObject>>(Reader.ReadToEnd());
-						if (SearchResults == null)
+						Results = JsonConvert.DeserializeObject<List<BlueprintJsonObject>>(await Reader.ReadToEndAsync());
+						if (Results == null || Results.Count == 0)
 						{
-							SearchResults = new List<BlueprintJsonObject>() { new BlueprintJsonObject("No Results Found") };
+							Results = new List<BlueprintJsonObject>() { new BlueprintJsonObject("No Results Found") };
 						}
 					}
 					File.Delete(SearchResultsPath);
 				}
 				else
 				{
-					MessageBox.Show("BlueprintSearchVS couldn't find SearchResults.json.\nPlease install FindInBlueprintsExternal Plugin inside \"/Engine/Plugins\"", "BlueprintSearchVS Warning");
+					ErrorMessages.Add("BlueprintSearchVS couldn't find SearchResults.json.\nPlease install FindInBlueprintsExternal Plugin inside \"/Engine/Plugins\"");
 				}
 			}
-
-			return SearchResults;
 		}
 	}
 }

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindow.cs
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindow.cs
@@ -22,6 +22,10 @@ namespace BlueprintSearch
 	[Guid("e49092ab-48f9-4fb9-88d4-3cd3e5fcfa36")]
 	public class BlueprintSearchVSWindow : ToolWindowPane
 	{
+		public BlueprintSearchWindowControl WindowControl = null;
+
+		public BlueprintSearchVSWindowVM WindowVM = null;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="BlueprintSearchVSWindow"/> class.
 		/// </summary>
@@ -29,10 +33,18 @@ namespace BlueprintSearch
 		{
 			this.Caption = "BlueprintSearchWindow";
 
+			this.WindowVM = new BlueprintSearchVSWindowVM();
+			this.WindowControl = new BlueprintSearchWindowControl(this.WindowVM);
+
 			// This is the user control hosted by the tool window; Note that, even if this class implements IDisposable,
 			// we are not calling Dispose on this object. This is because ToolWindowPane calls Dispose on
 			// the object returned by the Content property.
-			this.Content = new BlueprintSearchWindowControl();
+			this.Content = this.WindowControl;
+		}
+
+		public void Shutdown()
+		{
+			this.WindowVM?.CancelSearch();
 		}
 	}
 }

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml
@@ -12,29 +12,24 @@
 			 toolkit:Themes.UseVsTheme="True"
 			 UseLayoutRounding="True"
 			 Name="MyToolWindow">
-
+	<UserControl.Resources>
+		<BooleanToVisibilityConverter x:Key="BooleanToVisibility"/>
+	</UserControl.Resources>
 	<Grid>
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="*"/>
+			<ColumnDefinition Width="auto"/>
 		</Grid.ColumnDefinitions>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="auto"/>
 			<RowDefinition Height="auto"/>
-			<RowDefinition Height="1*"/>
+			<RowDefinition Height="*"/>
 		</Grid.RowDefinitions>
-		<TextBlock Margin="3" FontSize="12" FontFamily="Verdana" HorizontalAlignment="Left" Grid.Row="0">BlueprintSearchWindow</TextBlock>
-		<Grid Grid.Row="1">
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*"/>
-				<ColumnDefinition Width="auto"/>
-			</Grid.ColumnDefinitions>
-			<Grid.RowDefinitions>
-				<RowDefinition Height="auto"/>
-			</Grid.RowDefinitions>
-			<TextBox x:Name="SearchValue" BorderThickness="0.01" GotFocus="SearchBarGotFocus" KeyDown="OnKeyDownHandler" Grid.Column="0" Grid.Row="0">Type something to search</TextBox>
-			<Button Content="Search" Click="SearchButtonClick" Name="SearchButton"  BorderThickness="0.01" Grid.Column="1" Grid.Row="0"/>
-		</Grid>
-		<TreeView x:Name="ResultsView" Grid.Row="2">
+		<TextBox Grid.Row="0" Grid.Column="0" x:Name="SearchValue" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" BorderThickness="0.01" KeyDown="OnKeyDownHandler"></TextBox>
+		<Button Grid.Row="0" Grid.Column="1" Content="Search" Click="SearchButtonClick" Name="SearchButton" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.AccentBorderKey}}" BorderThickness="1" Visibility="{Binding CanSearch, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"/>
+		<Button Grid.Row="0" Grid.Column="1" Content="Cancel" Click="CancelButtonClick" Name="CancelButton" BorderBrush="{DynamicResource {x:Static vsshell:VsBrushes.AccentBorderKey}}" BorderThickness="1" Visibility="{Binding CanCancel, Mode=OneWay, Converter={StaticResource BooleanToVisibility}}"/>
+		<ProgressBar Grid.Row="1" Grid.ColumnSpan="2" IsIndeterminate="{Binding IsSearching}" BorderThickness="0" Height="5" Visibility="{Binding IsSearching, Converter={StaticResource BooleanToVisibility}}"/>
+		<TreeView Grid.Row="2" Grid.ColumnSpan="2" x:Name="ResultsView" ItemsSource="{Binding SearchResults}">
 			<TreeView.ItemTemplate>
 				<HierarchicalDataTemplate ItemsSource="{Binding Children}">
 					<TreeViewItem Header="{Binding Value}"/>

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml.cs
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml.cs
@@ -4,6 +4,7 @@
 
 using BlueprintSearch.Commands.CommandHandlers;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using System.Diagnostics.CodeAnalysis;
 using System.Windows;
 using System.Windows.Controls;
@@ -17,24 +18,22 @@ namespace BlueprintSearch
 	/// </summary>
 	public partial class BlueprintSearchWindowControl : UserControl
 	{
+		BlueprintSearchVSWindowVM ViewModel = null;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="BlueprintSearchWindowControl"/> class.
 		/// </summary>
-		public BlueprintSearchWindowControl()
+		public BlueprintSearchWindowControl(BlueprintSearchVSWindowVM inViewModel)
 		{
+			ViewModel = inViewModel;
+			this.DataContext = ViewModel;
 			this.InitializeComponent();
-		}
-
-		public void SearchBarGotFocus(object InSenderObject, RoutedEventArgs InEventArgs)
-		{
-			TextBox SearchBox = (TextBox)InSenderObject;
-			SearchBox.Text = string.Empty;
-			SearchBox.GotFocus -= SearchBarGotFocus;
 		}
 
 		private void OnKeyDownHandler(object InSenderObject, KeyEventArgs InEventArgs)
 		{
-			if(InEventArgs.Key == Key.Enter)
+			ThreadHelper.ThrowIfNotOnUIThread("BlueprintSearchWindowControl.OnKeyDownHandler");
+			if (InEventArgs.Key == Key.Enter)
 			{
 				SearchButtonClick(InSenderObject, null);
 			}
@@ -45,13 +44,21 @@ namespace BlueprintSearch
 		/// </summary>
 		/// <param name="sender">The event sender.</param>
 		/// <param name="e">The event args.</param>
-		[SuppressMessage("Microsoft.Globalization", "CA1300:SpecifyMessageBoxOptions", Justification = "Sample code")]
-		[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Default event handler naming pattern")]
 		private void SearchButtonClick(object InSenderObject, RoutedEventArgs InEventArgs)
 		{
 			ThreadHelper.ThrowIfNotOnUIThread("BlueprintSearchWindowControl.SearchButtonClick");
-			ExecuteSearchHandler ExecuteSearch = new ExecuteSearchHandler();
-			ResultsView.ItemsSource = ExecuteSearch.MakeSearch(SearchValue.Text);
+			ViewModel.HandleSearch();
+		}
+
+		/// <summary>
+		/// Handles click on the button by displaying a message box.
+		/// </summary>
+		/// <param name="sender">The event sender.</param>
+		/// <param name="e">The event args.</param>
+		private void CancelButtonClick(object InSenderObject, RoutedEventArgs InEventArgs)
+		{
+			ThreadHelper.ThrowIfNotOnUIThread("BlueprintSearchWindowControl.SearchButtonClick");
+			ViewModel.CancelSearch();
 		}
 	}
 }

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml.cs
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowControl.xaml.cs
@@ -42,8 +42,8 @@ namespace BlueprintSearch
 		/// <summary>
 		/// Handles click on the button by displaying a message box.
 		/// </summary>
-		/// <param name="sender">The event sender.</param>
-		/// <param name="e">The event args.</param>
+		/// <param name="InSenderObject">The event sender.</param>
+		/// <param name="InEventArgs">The event args.</param>
 		private void SearchButtonClick(object InSenderObject, RoutedEventArgs InEventArgs)
 		{
 			ThreadHelper.ThrowIfNotOnUIThread("BlueprintSearchWindowControl.SearchButtonClick");
@@ -53,8 +53,8 @@ namespace BlueprintSearch
 		/// <summary>
 		/// Handles click on the button by displaying a message box.
 		/// </summary>
-		/// <param name="sender">The event sender.</param>
-		/// <param name="e">The event args.</param>
+		/// <param name="InSenderObject">The event sender.</param>
+		/// <param name="InEventArgs">The event args.</param>
 		private void CancelButtonClick(object InSenderObject, RoutedEventArgs InEventArgs)
 		{
 			ThreadHelper.ThrowIfNotOnUIThread("BlueprintSearchWindowControl.SearchButtonClick");

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowVM.cs
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowVM.cs
@@ -1,3 +1,7 @@
+// Copyright (C) Coconut Lizard Limited. All rights reserved.
+
+// ---------------------------------------------------------
+
 using BlueprintSearch.Commands.CommandHandlers;
 using BlueprintSearch.Commands.CommandHelpers;
 using Microsoft.VisualStudio.Threading;
@@ -135,18 +139,11 @@ namespace BlueprintSearch
 			{
 				if (PathFinderHelper.FindUEProject(out string UEProjectPath))
 				{
-					if (PathFinderHelper.FindPaths(UEProjectPath) == false)
-					{
-						return false;
-					}
-				}
-				else
-				{
-					return false;
+					return PathFinderHelper.FindPaths(UEProjectPath);
 				}
 			}
 
-			return true;
+			return false;
 		}
 	}
 }

--- a/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowVM.cs
+++ b/Source/BlueprintSearchVSExtension/Source/UI/ToolWindows/BlueprintSearchWindow/BlueprintSearchVSWindowVM.cs
@@ -1,0 +1,152 @@
+using BlueprintSearch.Commands.CommandHandlers;
+using BlueprintSearch.Commands.CommandHelpers;
+using Microsoft.VisualStudio.Threading;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace BlueprintSearch
+{
+	public class BlueprintSearchVSWindowVM : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		bool isSearching = false;
+		public bool IsSearching
+		{
+			get => isSearching;
+			set
+			{
+				isSearching = value;
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(IsSearching)));
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(CanSearch)));
+			}
+		}
+
+		string searchText = string.Empty;
+		public string SearchText
+		{
+			get => searchText;
+			set
+			{
+				searchText = value;
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(SearchText)));
+			}
+		}
+
+		ObservableCollection<BlueprintJsonObject> searchResults = new ObservableCollection<BlueprintJsonObject>();
+		public ObservableCollection<BlueprintJsonObject> SearchResults
+		{
+			get => searchResults;
+			set
+			{
+				searchResults = value;
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(SearchResults)));
+			}
+		}
+
+		CancellationTokenSource cancellationTokenSource = null;
+		public CancellationTokenSource CancellationSource
+		{
+			get => cancellationTokenSource;
+			set
+			{
+				cancellationTokenSource = value;
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(CancellationSource)));
+				PropertyChanged.Invoke(this, new PropertyChangedEventArgs(nameof(CanCancel)));
+			}
+		}
+
+		// a custom IValueConverter that implements invertible boolean to visibility conversion is preferable for this long term.
+		public bool CanSearch => !IsSearching;
+		public bool CanCancel => CancellationSource != null;
+
+		public void CancelSearch()
+		{
+			CancellationSource?.Cancel();
+		}
+
+		public void HandleSearch()
+		{
+			if (IsSearching)
+			{
+				CancelSearch();
+			}
+			else if (string.IsNullOrEmpty(SearchText) == false)
+			{
+				IsSearching = true;
+				CancellationSource = new CancellationTokenSource();
+				Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.RunAsync(() => SearchForSymbolAsync());
+			}
+		}
+
+		private async Task SearchForSymbolAsync()
+		{
+			if (await EnsureProjectSetupAsync())
+			{
+				if (CancellationSource != null && !CancellationSource.IsCancellationRequested)
+				{
+					try
+					{
+						// switch off main thread to run the search, avoid UI hang
+						await TaskScheduler.Default;
+						ExecuteSearchHandler search = new ExecuteSearchHandler();
+						try
+						{
+							await search.MakeSearchAsync(SearchText, CancellationSource.Token);
+						}
+						catch (Exception e)
+						{
+							search.ErrorMessages.Add($"Search failed due to: {e.Message}");
+						}
+
+						// switch back to main thread once the search has completed so we can update UI element bindings safely.
+						await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+						if (search.ErrorMessages.Count == 0)
+						{
+							SearchResults.Clear();
+							search.Results.ForEach(result => SearchResults.Add(result));
+						}
+						else
+						{
+							MessageBox.Show(string.Join(",", search.ErrorMessages), "BlueprintSearchVS Error");
+						}
+					}
+					catch (Exception e)
+					{
+						MessageBox.Show($"BlueprintSearchVS Error: {e.Message}"); ;
+					}
+				}
+			}
+
+			IsSearching = false;
+			CancellationSource = null;
+		}
+
+		private async Task<bool> EnsureProjectSetupAsync()
+		{
+			await Microsoft.VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+			if (string.IsNullOrEmpty(PathFinderHelper.UEEditorFilePath))
+			{
+				if (PathFinderHelper.FindUEProject(out string UEProjectPath))
+				{
+					if (PathFinderHelper.FindPaths(UEProjectPath) == false)
+					{
+						return false;
+					}
+				}
+				else
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
- Rework existing external process handling to avoid blocking the UI thread during search.
- Add cancellation token for handing cancellation of search task including clean up of external process.
- Add ViewModel and bindings to the tool window, update window XAML to support search/cancel and a progress bar for user feedback.
- Refactor to remove compilation/analyzer warnings regarding threading.